### PR TITLE
update to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,21 @@ Commands seem to be a bit contradictory, but the list of dimensions is actually 
 - `/nofly config reload` - Reloads the config file.
 - `/nofly config add <dimension>` - Adds a dimension to the allowed list.
 - `/nofly config remove <dimension>` - Removes a dimension from the allowed list.
+- `/nofly config show` - Shows all dimensions in the allowed list.
 
 I intend on adding more commands and features in the future, but this will suffice for now.
 
 # Versions
 | Mod Version | Loader | Game Version(s) |
 |-------------|--------|-----------------|
+| 1.1.0       | Fabric | 1.21            |
 | 1.0.0       | Fabric | 1.21            |
+
+## Changelog
+### 1.1.0
+- Fixed a bug where the config wouldn't be loaded on startup
+- New command: `/nofly config show` to show all dimensions in the allowed list
+- When doing `/nofly config add <dimension>`, it will now suggest dimensions that are in the list of dimensions
 
 # Environment
 This is a server-side mod! It is not required to be downloaded client-side, unless you want to host a LAN world (or run this on your own world)

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,11 @@ org.gradle.parallel=true
 # check these on https://fabricmc.net/develop
 minecraft_version=1.21
 yarn_mappings=1.21+build.9
-loader_version=0.16.14
+loader_version=0.16.0
 loom_version=1.10-SNAPSHOT
 
 # Mod Properties
-mod_version=1.21+1.0.0-fabric
+mod_version=1.21+1.1.0-fabric
 maven_group=me.imgalvin.restrictedflying
 archives_base_name=restricted-flying
 

--- a/src/main/java/me/imgalvin/restrictedflying/RestrictedFlying.java
+++ b/src/main/java/me/imgalvin/restrictedflying/RestrictedFlying.java
@@ -1,13 +1,18 @@
 package me.imgalvin.restrictedflying;
 
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.argument.IdentifierArgumentType;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.WorldSavePath;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.Identifier;
@@ -23,139 +28,190 @@ import java.nio.file.*;
 import java.util.*;
 
 public class RestrictedFlying implements ModInitializer {
-	public static final String MOD_ID = "restricted-flying";
-	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
-	public static Set<RegistryKey<World>> allowedFlightDimensions = new HashSet<>();
+    public static final String MOD_ID = "restricted-flying";
+    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+    public static Set<RegistryKey<World>> allowedFlightDimensions = new HashSet<>();
 
-	private static Path configPath;
+    private static Path configPath;
 
-	@Override
-	public void onInitialize() {
-		LOGGER.info("Restricted Flying mod is initializing!");
+    private static final SuggestionProvider<ServerCommandSource> DIMENSION_SUGGESTIONS = (context, builder) -> {
+        return CommandSource.suggestIdentifiers(
+                context.getSource().getServer().getRegistryManager().get(RegistryKeys.WORLD).getIds(),
+                builder
+        );
+    };
 
-		// Register flight restriction logic
-		ServerTickEvents.END_WORLD_TICK.register(world -> {
-			for (ServerPlayerEntity player : world.getPlayers()) {
-				if (player.isFallFlying()) {
-					RegistryKey<World> dimension = player.getWorld().getRegistryKey();
-					if (!allowedFlightDimensions.contains(dimension)) {
-						player.stopFallFlying();
-						player.sendMessage(Text.literal("Elytra flight is disabled in this dimension."), true);
 
-						ItemStack chestItem = player.getEquippedStack(EquipmentSlot.CHEST);
-						if (chestItem.getItem().toString().toLowerCase().contains("elytra")) {
-							ItemStack elytraCopy = chestItem.copy();
-							player.getInventory().armor.set(2, ItemStack.EMPTY);
-							player.dropItem(elytraCopy, false, true);
-						}
-					}
-				}
-			}
-		});
+    @Override
+    public void onInitialize() {
+        LOGGER.info("Restricted Flying mod is initializing!");
 
-		// Register commands
-		CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
-			dispatcher.register(CommandManager.literal("noflying")
-					.then(CommandManager.literal("config")
-							.requires(source -> source.hasPermissionLevel(4)) // Admin only
-							.then(CommandManager.literal("reload")
-									.executes(ctx -> {
-										loadConfig(ctx.getSource());
-										return 1;
-									})
-							)
-							.then(CommandManager.literal("add")
-									.then(CommandManager.argument("dimension", StringArgumentType.string())
-											.executes(ctx -> {
-												String dim = StringArgumentType.getString(ctx, "dimension");
-												Identifier id = Identifier.tryParse(dim);
-												if (id == null) {
-													ctx.getSource().sendError(Text.literal("Invalid dimension identifier: " + dim));
-													return 0;
-												}
-												RegistryKey<World> key = RegistryKey.of(RegistryKey.ofRegistry(Identifier.of("minecraft", "dimension")), id);
-												if (allowedFlightDimensions.add(key)) {
-													saveConfig(ctx.getSource());
-													ctx.getSource().sendFeedback(() -> Text.literal("Added " + dim + " to allowed flight dimensions."), false);
-												} else {
-													ctx.getSource().sendFeedback(() -> Text.literal("Dimension " + dim + " is already allowed."), false);
-												}
-												return 1;
-											})
-									)
-							)
-							.then(CommandManager.literal("remove")
-									.then(CommandManager.argument("dimension", StringArgumentType.string())
-											.executes(ctx -> {
-												String dim = StringArgumentType.getString(ctx, "dimension");
-												Identifier id = Identifier.tryParse(dim);
-												if (id == null) {
-													ctx.getSource().sendError(Text.literal("Invalid dimension identifier: " + dim));
-													return 0;
-												}
-												RegistryKey<World> key = RegistryKey.of(RegistryKey.ofRegistry(Identifier.of("minecraft", "dimension")), id);
-												if (allowedFlightDimensions.remove(key)) {
-													saveConfig(ctx.getSource());
-													ctx.getSource().sendFeedback(() -> Text.literal("Removed " + dim + " from allowed flight dimensions."), false);
-												} else {
-													ctx.getSource().sendFeedback(() -> Text.literal("Dimension " + dim + " was not in the allowed list."), false);
-												}
-												return 1;
-											})
-									)
-							)
-					)
-			);
-		});
-	}
+        // Register flight restriction logic
+        ServerTickEvents.END_WORLD_TICK.register(world -> {
+            for (ServerPlayerEntity player : world.getPlayers()) {
+                if (player.isFallFlying()) {
+                    RegistryKey<World> dimension = player.getWorld().getRegistryKey();
+                    if (!allowedFlightDimensions.contains(dimension)) {
+                        player.stopFallFlying();
+                        player.sendMessage(Text.literal("Elytra flight is disabled in this dimension."), true);
 
-	// Config
-	private static void loadConfig(ServerCommandSource source) {
-		try {
-			if (configPath == null) {
-				Path worldDir = source.getServer().getSavePath(WorldSavePath.ROOT);
-				configPath = worldDir.resolve("allowed_flight.txt");
-			}
+                        ItemStack chestItem = player.getEquippedStack(EquipmentSlot.CHEST);
+                        if (chestItem.getItem().toString().toLowerCase().contains("elytra")) {
+                            ItemStack elytraCopy = chestItem.copy();
+                            player.getInventory().armor.set(2, ItemStack.EMPTY);
+                            player.dropItem(elytraCopy, false, true);
+                        }
+                    }
+                }
+            }
+        });
 
-			allowedFlightDimensions.clear();
+        // Register commands
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
+            dispatcher.register(CommandManager.literal("noflying")
+                    .then(CommandManager.literal("config")
+                            .requires(source -> source.hasPermissionLevel(4)) // Admin only
+                            .then(CommandManager.literal("reload")
+                                    .executes(ctx -> {
+                                        loadConfig(ctx.getSource());
+                                        return 1;
+                                    })
+                            )
+                            .then(CommandManager.literal("add")
+                                    .then(CommandManager.argument("dimension", IdentifierArgumentType.identifier())
+                                            .suggests(DIMENSION_SUGGESTIONS)
+                                            .executes(ctx -> {
+                                                Identifier id = net.minecraft.command.argument.IdentifierArgumentType.getIdentifier(ctx, "dimension");
+                                                if (id == null) {
+                                                    ctx.getSource().sendError(Text.literal("Invalid dimension identifier."));
+                                                    return 0;
+                                                }
+                                                RegistryKey<World> key = RegistryKey.of(RegistryKeys.WORLD, id);
+                                                if (allowedFlightDimensions.add(key)) {
+                                                    saveConfig(ctx.getSource());
+                                                    ctx.getSource().sendFeedback(() -> Text.literal("Added " + id + " to allowed flight dimensions."), false);
+                                                } else {
+                                                    ctx.getSource().sendFeedback(() -> Text.literal("Dimension " + id + " is already allowed."), false);
+                                                }
+                                                return 1;
+                                            })
+                                    )
+                            )
+                            .then(CommandManager.literal("remove")
+                                    .then(CommandManager.argument("dimension", IdentifierArgumentType.identifier())
+                                            .suggests(DIMENSION_SUGGESTIONS)
+                                            .executes(ctx -> {
+                                                Identifier id = net.minecraft.command.argument.IdentifierArgumentType.getIdentifier(ctx, "dimension");
+                                                if (id == null) {
+                                                    ctx.getSource().sendError(Text.literal("Invalid dimension identifier."));
+                                                    return 0;
+                                                }
+                                                RegistryKey<World> key = RegistryKey.of(RegistryKeys.WORLD, id);
+                                                if (allowedFlightDimensions.remove(key)) {
+                                                    saveConfig(ctx.getSource());
+                                                    ctx.getSource().sendFeedback(() -> Text.literal("Added " + id + " to allowed flight dimensions."), false);
+                                                } else {
+                                                    ctx.getSource().sendFeedback(() -> Text.literal("Dimension " + id + " is already allowed."), false);
+                                                }
+                                                return 1;
+                                            })
+                                    )
+                            )
+                            .then(CommandManager.literal("show")
+                                    .executes(ctx -> {
+                                        StringBuilder sb = new StringBuilder("Allowed flight dimensions: ");
+                                        if (allowedFlightDimensions.isEmpty()) {
+                                            ctx.getSource().sendFeedback(() -> Text.literal("No flying is allowed in any dimensions").formatted(Formatting.RED), false);
+                                            return 1;
+                                        }
+                                        for (RegistryKey<World> key : allowedFlightDimensions) {
+                                            sb.append(key.getValue().toString()).append(", ");
+                                        }
+                                        if (!sb.isEmpty()) {
+                                            sb.setLength(sb.length() - 2); // Remove trailing comma and space
+                                        }
+                                        ctx.getSource().sendFeedback(() -> Text.literal(sb.toString()), false);
+                                        return 1;
+                                    })
+                            )
+                    )
+            );
+        });
+    }
 
-			if (Files.exists(configPath)) {
-				String content = Files.readString(configPath).trim();
-				if (!content.isEmpty()) {
-					String[] parts = content.split(",");
-					for (String part : parts) {
-						Identifier id = Identifier.tryParse(part.trim());
-						if (id != null) {
-							RegistryKey<World> key = RegistryKey.of(RegistryKey.ofRegistry(Identifier.of("minecraft", "dimension")), id);
-							allowedFlightDimensions.add(key);
-						}
-					}
-				}
-			}
-			source.sendFeedback(() -> Text.literal("Flight config reloaded."), false);
-		} catch (IOException e) {
-			LOGGER.error("Failed to load config", e);
-			source.sendError(Text.literal("Error loading config."));
-		}
-	}
+    // Config
+    private static void loadConfig(ServerCommandSource source) {
+        try {
+            if (configPath == null) {
+                Path worldDir = source.getServer().getSavePath(WorldSavePath.ROOT);
+                configPath = worldDir.resolve("allowed_flight.txt");
+            }
 
-	private static void saveConfig(ServerCommandSource source) {
-		try {
-			if (configPath == null) {
-				Path worldDir = source.getServer().getSavePath(WorldSavePath.ROOT);
-				configPath = worldDir.resolve("allowed_flight.txt");
-			}
+            allowedFlightDimensions.clear();
 
-			List<String> ids = new ArrayList<>();
-			for (RegistryKey<World> key : allowedFlightDimensions) {
-				ids.add(key.getValue().toString());
-			}
+            if (Files.exists(configPath)) {
+                String content = Files.readString(configPath).trim();
+                if (!content.isEmpty()) {
+                    String[] parts = content.split(",");
+                    for (String part : parts) {
+                        Identifier id = Identifier.tryParse(part.trim());
+                        if (id != null) {
+                            RegistryKey<World> key = RegistryKey.of(RegistryKey.ofRegistry(Identifier.of("minecraft", "dimension")), id);
+                            allowedFlightDimensions.add(key);
+                        }
+                    }
+                }
+            }
+            source.sendFeedback(() -> Text.literal("Flight config reloaded."), false);
+        } catch (IOException e) {
+            LOGGER.error("Failed to load config", e);
+            source.sendError(Text.literal("Error loading config."));
+        }
+    }
 
-			Files.writeString(configPath, String.join(",", ids), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-			source.sendFeedback(() -> Text.literal("Config saved."), false);
-		} catch (IOException e) {
-			LOGGER.error("Failed to save config", e);
-			source.sendError(Text.literal("Error saving config."));
-		}
-	}
+    // Sure lets overload this method
+    public static void loadConfig(Path path) {
+        allowedFlightDimensions.clear();
+        configPath = path;
+
+        LOGGER.info("Loading config from: {}", path.toString());
+
+        try {
+            if (Files.exists(configPath)) {
+                String content = Files.readString(configPath).trim();
+                if (!content.isEmpty()) {
+                    String[] parts = content.split(",");
+                    for (String part : parts) {
+                        Identifier id = Identifier.tryParse(part.trim());
+                        if (id != null) {
+                            RegistryKey<World> key = RegistryKey.of(RegistryKey.ofRegistry(Identifier.of("minecraft", "dimension")), id);
+                            allowedFlightDimensions.add(key);
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.error("Failed to load config", e);
+        }
+    }
+
+    private static void saveConfig(ServerCommandSource source) {
+        try {
+            if (configPath == null) {
+                Path worldDir = source.getServer().getSavePath(WorldSavePath.ROOT);
+                configPath = worldDir.resolve("allowed_flight.txt");
+            }
+
+            List<String> ids = new ArrayList<>();
+            for (RegistryKey<World> key : allowedFlightDimensions) {
+                ids.add(key.getValue().toString());
+            }
+
+            Files.writeString(configPath, String.join(",", ids), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            source.sendFeedback(() -> Text.literal("Config saved."), false);
+        } catch (IOException e) {
+            LOGGER.error("Failed to save config", e);
+            source.sendError(Text.literal("Error saving config."));
+        }
+    }
 }

--- a/src/main/java/me/imgalvin/restrictedflying/RestrictedFlying.java
+++ b/src/main/java/me/imgalvin/restrictedflying/RestrictedFlying.java
@@ -109,7 +109,7 @@ public class RestrictedFlying implements ModInitializer {
                                                 RegistryKey<World> key = RegistryKey.of(RegistryKeys.WORLD, id);
                                                 if (allowedFlightDimensions.remove(key)) {
                                                     saveConfig(ctx.getSource());
-                                                    ctx.getSource().sendFeedback(() -> Text.literal("Added " + id + " to allowed flight dimensions."), false);
+                                                    ctx.getSource().sendFeedback(() -> Text.literal("Removed " + id + " from allowed flight dimensions."), false);
                                                 } else {
                                                     ctx.getSource().sendFeedback(() -> Text.literal("Dimension " + id + " is already allowed."), false);
                                                 }

--- a/src/main/java/me/imgalvin/restrictedflying/RestrictedFlying.java
+++ b/src/main/java/me/imgalvin/restrictedflying/RestrictedFlying.java
@@ -111,7 +111,7 @@ public class RestrictedFlying implements ModInitializer {
                                                     saveConfig(ctx.getSource());
                                                     ctx.getSource().sendFeedback(() -> Text.literal("Removed " + id + " from allowed flight dimensions."), false);
                                                 } else {
-                                                    ctx.getSource().sendFeedback(() -> Text.literal("Dimension " + id + " is already allowed."), false);
+                                                    ctx.getSource().sendFeedback(() -> Text.literal("Dimension " + id + " is not in the allowed list."), false);
                                                 }
                                                 return 1;
                                             })

--- a/src/main/java/me/imgalvin/restrictedflying/RestrictedFlying.java
+++ b/src/main/java/me/imgalvin/restrictedflying/RestrictedFlying.java
@@ -156,7 +156,7 @@ public class RestrictedFlying implements ModInitializer {
                     for (String part : parts) {
                         Identifier id = Identifier.tryParse(part.trim());
                         if (id != null) {
-                            RegistryKey<World> key = RegistryKey.of(RegistryKey.ofRegistry(Identifier.of("minecraft", "dimension")), id);
+                            RegistryKey<World> key = RegistryKey.of(RegistryKeys.WORLD, id);
                             allowedFlightDimensions.add(key);
                         }
                     }
@@ -184,7 +184,7 @@ public class RestrictedFlying implements ModInitializer {
                     for (String part : parts) {
                         Identifier id = Identifier.tryParse(part.trim());
                         if (id != null) {
-                            RegistryKey<World> key = RegistryKey.of(RegistryKey.ofRegistry(Identifier.of("minecraft", "dimension")), id);
+                            RegistryKey<World> key = RegistryKey.of(RegistryKeys.WORLD, id);
                             allowedFlightDimensions.add(key);
                         }
                     }

--- a/src/main/java/me/imgalvin/restrictedflying/RestrictedFlying.java
+++ b/src/main/java/me/imgalvin/restrictedflying/RestrictedFlying.java
@@ -1,6 +1,5 @@
 package me.imgalvin.restrictedflying;
 
-import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
@@ -34,12 +33,10 @@ public class RestrictedFlying implements ModInitializer {
 
     private static Path configPath;
 
-    private static final SuggestionProvider<ServerCommandSource> DIMENSION_SUGGESTIONS = (context, builder) -> {
-        return CommandSource.suggestIdentifiers(
-                context.getSource().getServer().getRegistryManager().get(RegistryKeys.WORLD).getIds(),
-                builder
-        );
-    };
+    private static final SuggestionProvider<ServerCommandSource> DIMENSION_SUGGESTIONS = (context, builder) -> CommandSource.suggestIdentifiers(
+            context.getSource().getServer().getRegistryManager().get(RegistryKeys.WORLD).getIds(),
+            builder
+    );
 
 
     @Override

--- a/src/main/java/me/imgalvin/restrictedflying/mixin/WorldLoadMixin.java
+++ b/src/main/java/me/imgalvin/restrictedflying/mixin/WorldLoadMixin.java
@@ -1,0 +1,17 @@
+package me.imgalvin.restrictedflying.mixin;
+
+import me.imgalvin.restrictedflying.RestrictedFlying;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.WorldSavePath;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class WorldLoadMixin {
+    @Inject(at = @At("HEAD"), method = "loadWorld")
+    private void init(CallbackInfo info) {
+        RestrictedFlying.loadConfig(MinecraftServer.class.cast(this).getSavePath(WorldSavePath.ROOT).resolve("allowed_flight.txt"));
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,9 +21,12 @@
 		]
 	},
 	"depends": {
-		"fabricloader": ">=0.16.14",
+		"fabricloader": ">=0.16.0",
 		"minecraft": "~1.21",
 		"java": ">=21",
 		"fabric-api": "*"
-	}
+	},
+	"mixins": [
+		"restricted-flying.mixins.json"
+	]
 }

--- a/src/main/resources/restricted-flying.mixins.json
+++ b/src/main/resources/restricted-flying.mixins.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "me.imgalvin.restrictedflying.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "WorldLoadMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
- [x] Fixed a bug where the config wouldn't be loaded on startup
- [x] New command: `/nofly config show` to show all dimensions in the allowed list
- [x] When doing `/nofly config add <dimension>`, it will now suggest dimensions that are in the list of dimensions